### PR TITLE
Use instance id directly

### DIFF
--- a/src/vertex_pulling/draw.rs
+++ b/src/vertex_pulling/draw.rs
@@ -173,14 +173,13 @@ impl EntityRenderCommand for DrawVertexPulledCuboids {
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let entry = buffer_cache.into_inner().entries.get(&item).unwrap();
-        let num_indices =
-            num_indices_for_cuboids(entry.instance_buffer.get().len().try_into().unwrap());
+        let num_cuboids = entry.instance_buffer.get().len().try_into().unwrap();
         pass.set_index_buffer(
             index_buffer.into_inner().buffer().unwrap().slice(..),
             0,
             IndexFormat::Uint32,
         );
-        pass.draw_indexed(0..num_indices, 0, 0..1);
+        pass.draw_indexed(0..num_indices_for_cuboids(1), 0, 0..num_cuboids);
         RenderCommandResult::Success
     }
 }

--- a/src/vertex_pulling/extract.rs
+++ b/src/vertex_pulling/extract.rs
@@ -1,5 +1,4 @@
 use super::cuboid_cache::CuboidBufferCache;
-use super::index_buffer::CuboidsIndexBuffer;
 use crate::clipping_planes::*;
 use crate::cuboids::*;
 use crate::ColorOptions;
@@ -24,7 +23,6 @@ pub(crate) fn extract_cuboids(
     color_options: Extract<Res<ColorOptionsMap>>,
     mut color_options_uniforms: ResMut<DynamicUniformBuffer<ColorOptions>>,
     mut cuboid_buffers: ResMut<CuboidBufferCache>,
-    mut index_buffer: ResMut<CuboidsIndexBuffer>,
     mut transform_uniforms: ResMut<DynamicUniformBuffer<CuboidsTransform>>,
 ) {
     transform_uniforms.clear();
@@ -69,8 +67,6 @@ pub(crate) fn extract_cuboids(
         entry.keep_alive = true;
         entry.position = transform.position();
         entry.transform_index = transform_uniforms.push(transform);
-
-        index_buffer.grow_to_fit_num_cuboids(cuboids.instances.len().try_into().unwrap());
     }
 
     cuboid_buffers.cull_entities();

--- a/src/vertex_pulling/index_buffer.rs
+++ b/src/vertex_pulling/index_buffer.rs
@@ -1,70 +1,61 @@
-use bevy::render::{
-    render_resource::{Buffer, BufferUsages, BufferVec},
-    renderer::{RenderDevice, RenderQueue},
+use bevy::{
+    core::cast_slice,
+    ecs::system::lifetimeless::SRes,
+    prelude::HandleUntyped,
+    reflect::TypeUuid,
+    render::{
+        render_asset::RenderAsset,
+        render_resource::{Buffer, BufferInitDescriptor, BufferUsages},
+        renderer::RenderDevice,
+    },
 };
 
-pub struct CuboidsIndexBuffer {
-    buffer: BufferVec<u32>,
-    dirty: bool,
-}
+#[derive(Default, TypeUuid)]
+#[uuid = "8f6d78a6-fffe-4e54-81db-08b0739a947a"]
+pub struct CuboidsIndexBuffer;
 
-impl Default for CuboidsIndexBuffer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CuboidsIndexBuffer {
-    pub fn new() -> Self {
-        Self {
-            buffer: BufferVec::new(BufferUsages::INDEX),
-            dirty: false,
-        }
-    }
-
-    pub fn grow_to_fit_num_cuboids(&mut self, num_cuboids: u32) {
-        /// The indices for all triangles in a cuboid mesh (given 8 corner
-        /// vertices).
-        ///
-        /// In addition to encoding the 3-bit cube corner index, we add 2 bits
-        /// to indicate which of the 3 faces is being rendered.
-        #[rustfmt::skip]
-        #[allow(clippy::unusual_byte_groupings)]
-        const CUBE_INDICES: [u32; NUM_CUBE_INDICES_USIZE] = [
-            0b00_000, 0b00_010, 0b00_001, 0b00_010, 0b00_011, 0b00_001, // face XY (0)
-            0b01_101, 0b01_100, 0b01_001, 0b01_001, 0b01_100, 0b01_000, // face XZ (1)
-            0b10_000, 0b10_100, 0b10_110, 0b10_000, 0b10_110, 0b10_010, // face YZ (2)
-        ];
-
-        let num_indices = num_indices_for_cuboids(num_cuboids);
-        let end: u32 = self.buffer.len().try_into().unwrap();
-        if end < num_indices {
-            for i in end..num_indices {
-                let cuboid = i / NUM_CUBE_INDICES_U32;
-                let cuboid_local = i % NUM_CUBE_INDICES_U32;
-                self.buffer
-                    .push((cuboid << 5) + CUBE_INDICES[cuboid_local as usize]);
-            }
-            self.dirty = true;
-        }
-    }
-
-    pub fn write_buffer(&mut self, render_device: &RenderDevice, render_queue: &RenderQueue) {
-        if self.dirty {
-            self.buffer.write_buffer(render_device, render_queue);
-            self.dirty = false;
-        }
-    }
-
-    pub fn buffer(&self) -> Option<&Buffer> {
-        self.buffer.buffer()
-    }
-}
+pub(crate) const CUBE_INDICES_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(CuboidsIndexBuffer::TYPE_UUID, 17343092250772987267);
 
 // Only 3 faces are actually drawn.
 const NUM_CUBE_INDICES_USIZE: usize = 3 * 3 * 2;
-const NUM_CUBE_INDICES_U32: u32 = 3 * 3 * 2;
 
-pub fn num_indices_for_cuboids(num_cuboids: u32) -> u32 {
-    num_cuboids * NUM_CUBE_INDICES_U32
+/// The indices for all triangles in a cuboid mesh (given 8 corner
+/// vertices).
+///
+/// In addition to encoding the 3-bit cube corner index, we add 2 bits
+/// to indicate which of the 3 faces is being rendered.
+#[rustfmt::skip]
+#[allow(clippy::unusual_byte_groupings)]
+pub(crate) const CUBE_INDICES: [u32; NUM_CUBE_INDICES_USIZE] = [
+    0b00_000, 0b00_010, 0b00_001, 0b00_010, 0b00_011, 0b00_001, // face XY (0)
+    0b01_101, 0b01_100, 0b01_001, 0b01_001, 0b01_100, 0b01_000, // face XZ (1)
+    0b10_000, 0b10_100, 0b10_110, 0b10_000, 0b10_110, 0b10_010, // face YZ (2)
+];
+
+impl RenderAsset for CuboidsIndexBuffer {
+    type ExtractedAsset = Self;
+
+    type PreparedAsset = Buffer;
+
+    type Param = SRes<RenderDevice>;
+
+    fn extract_asset(&self) -> Self::ExtractedAsset {
+        Self
+    }
+
+    fn prepare_asset(
+        _extracted_asset: Self::ExtractedAsset,
+        render_device: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
+    ) -> Result<
+        Self::PreparedAsset,
+        bevy::render::render_asset::PrepareAssetError<Self::ExtractedAsset>,
+    > {
+        let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            usage: BufferUsages::INDEX,
+            label: Some("Cuboid Index Buffer"),
+            contents: cast_slice(CUBE_INDICES.as_slice()),
+        });
+        Ok(buffer)
+    }
 }

--- a/src/vertex_pulling/plugin.rs
+++ b/src/vertex_pulling/plugin.rs
@@ -1,12 +1,10 @@
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::{AuxiliaryMeta, DrawCuboids, TransformsMeta, ViewMeta};
 use super::extract::{extract_clipping_planes, extract_cuboids};
-use super::index_buffer::CuboidsIndexBuffer;
 use super::pipeline::{CuboidsPipeline, CuboidsShaderDefs, VERTEX_PULLING_SHADER_HANDLE};
 use super::prepare::{
     prepare_auxiliary_bind_group, prepare_clipping_planes, prepare_color_options,
-    prepare_cuboid_transforms, prepare_cuboids, prepare_cuboids_index_buffer,
-    prepare_cuboids_view_bind_group,
+    prepare_cuboid_transforms, prepare_cuboids, prepare_cuboids_view_bind_group,
 };
 use super::queue::queue_cuboids;
 use crate::clipping_planes::GpuClippingPlaneRanges;
@@ -35,6 +33,15 @@ impl Plugin for VertexPullingRenderPlugin {
             VERTEX_PULLING_SHADER_HANDLE,
             Shader::from_wgsl(include_str!("vertex_pulling.wgsl")),
         );
+        {
+            use super::index_buffer::{CuboidsIndexBuffer, CUBE_INDICES_HANDLE};
+            use bevy::render::render_asset::RenderAssetPlugin;
+            app.add_asset::<CuboidsIndexBuffer>()
+                .add_plugin(RenderAssetPlugin::<CuboidsIndexBuffer>::default());
+            app.world
+                .resource_mut::<Assets<CuboidsIndexBuffer>>()
+                .set_untracked(CUBE_INDICES_HANDLE, CuboidsIndexBuffer);
+        }
 
         let maybe_msaa = app.world.get_resource::<Msaa>().cloned();
         let render_app = app.sub_app_mut(RenderApp);
@@ -52,7 +59,6 @@ impl Plugin for VertexPullingRenderPlugin {
             .add_render_command::<Opaque3d, DrawCuboids>()
             .init_resource::<AuxiliaryMeta>()
             .init_resource::<CuboidBufferCache>()
-            .init_resource::<CuboidsIndexBuffer>()
             .init_resource::<CuboidsPipeline>()
             .init_resource::<DynamicUniformBuffer<ColorOptions>>()
             .init_resource::<DynamicUniformBuffer<CuboidsTransform>>()
@@ -69,7 +75,6 @@ impl Plugin for VertexPullingRenderPlugin {
                     .after(prepare_color_options)
                     .after(prepare_clipping_planes),
             )
-            .add_system_to_stage(RenderStage::Prepare, prepare_cuboids_index_buffer)
             .add_system_to_stage(RenderStage::Prepare, prepare_cuboid_transforms)
             .add_system_to_stage(RenderStage::Prepare, prepare_cuboids)
             // HACK: prepare view bind group should happen in prepare phase, but

--- a/src/vertex_pulling/prepare.rs
+++ b/src/vertex_pulling/prepare.rs
@@ -1,6 +1,5 @@
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::{AuxiliaryMeta, TransformsMeta, ViewMeta};
-use super::index_buffer::CuboidsIndexBuffer;
 use super::pipeline::CuboidsPipeline;
 use crate::cuboids::CuboidsTransform;
 use crate::{ColorOptions, GpuClippingPlaneRanges};
@@ -60,15 +59,6 @@ pub(crate) fn prepare_auxiliary_bind_group(
             ],
         }));
     }
-}
-
-pub(crate) fn prepare_cuboids_index_buffer(
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
-    mut index_buffer: ResMut<CuboidsIndexBuffer>,
-) {
-    // Values already pushed in extract stage.
-    index_buffer.write_buffer(&render_device, &render_queue);
 }
 
 pub(crate) fn prepare_cuboid_transforms(

--- a/src/vertex_pulling/vertex_pulling.wgsl
+++ b/src/vertex_pulling/vertex_pulling.wgsl
@@ -110,10 +110,9 @@ fn discard_vertex() -> VertexOutput {
 }
 
 @vertex
-fn vertex(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) instance_index: u32) -> VertexOutput {
     var out: VertexOutput;
 
-    let instance_index = vertex_index >> 5u;
     let cuboid = cuboids.data[instance_index];
 
     // Check visibility mask.


### PR DESCRIPTION
Why use a resizing index vector when we can just use the instance id directly.

This PR changed the BufferVec index buffer into a constant-sized render asset.