### PR TITLE
Migration to bevy 0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy-aabb-in
 trace = ["bevy/trace_chrome"]
 
 [dependencies.bevy]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = ["bevy_asset", "bevy_core_pipeline", "bevy_render", "x11"]
 
 [dev-dependencies]
 rand = "0.8"
-smooth-bevy-cameras = { git = "https://github.com/bonsairobo/smooth-bevy-cameras", rev = "a1095b9bc" }
+smooth-bevy-cameras = { git = "https://github.com/olegomon/smooth-bevy-cameras" }

--- a/examples/wave.rs
+++ b/examples/wave.rs
@@ -58,14 +58,14 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<ColorOptionsMap>)
             let cuboids = Cuboids::new(instances);
             let aabb = cuboids.aabb();
             commands
-                .spawn_bundle(SpatialBundle::default())
-                .insert_bundle((cuboids, aabb, color_options_id));
+                .spawn(SpatialBundle::default())
+                .insert((cuboids, aabb, color_options_id));
         }
     }
 
     commands
-        .spawn_bundle(Camera3dBundle::default())
-        .insert_bundle(FpsCameraBundle::new(
+        .spawn(Camera3dBundle::default())
+        .insert(FpsCameraBundle::new(
             FpsCameraController {
                 translate_sensitivity: 2.0,
                 ..Default::default()
@@ -77,7 +77,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<ColorOptionsMap>)
 
 fn update_scalar_hue_options(time: Res<Time>, mut color_options_map: ResMut<ColorOptionsMap>) {
     let options = color_options_map.get_mut(ColorOptionsId(1));
-    let tv = 1000.0 * (time.seconds_since_startup().sin() + 1.0) as f32;
+    let tv = 1000.0 * (time.elapsed_seconds().sin() + 1.0);
     options.scalar_hue.max_visible = tv;
     options.scalar_hue.clamp_max = tv;
 }

--- a/src/color_options.rs
+++ b/src/color_options.rs
@@ -65,7 +65,7 @@ pub struct ScalarHueColorOptions {
 
 /// Resource used to create and modify a set of [`ColorOptions`] that are
 /// automatically synced to shader uniforms.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct ColorOptionsMap {
     // Consumed every frame during GPU buffering.
     options: Vec<ColorOptions>,

--- a/src/vertex_pulling.rs
+++ b/src/vertex_pulling.rs
@@ -7,5 +7,6 @@ mod index_buffer;
 mod pipeline;
 mod prepare;
 mod queue;
+mod buffers;
 
 pub mod plugin;

--- a/src/vertex_pulling/buffers.rs
+++ b/src/vertex_pulling/buffers.rs
@@ -1,0 +1,14 @@
+use bevy::prelude::{Deref, DerefMut, Resource};
+use bevy::render::render_resource::{DynamicUniformBuffer, UniformBuffer};
+use crate::clipping_planes::GpuClippingPlaneRanges;
+use crate::ColorOptions;
+use crate::cuboids::CuboidsTransform;
+
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct DynamicUniformBufferOfColorOptions(pub(crate) DynamicUniformBuffer<ColorOptions>);
+
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct DynamicUniformBufferOfCuboidTransforms(pub(crate) DynamicUniformBuffer<CuboidsTransform>);
+
+#[derive(Resource, Default, Deref, DerefMut)]
+pub(crate) struct UniformBufferOfGpuClippingPlaneRanges(pub(crate) UniformBuffer<GpuClippingPlaneRanges>);

--- a/src/vertex_pulling/cuboid_cache.rs
+++ b/src/vertex_pulling/cuboid_cache.rs
@@ -6,7 +6,7 @@ use bevy::{
     utils::HashMap,
 };
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub(crate) struct CuboidBufferCache {
     pub entries: HashMap<Entity, CachedCuboidBuffers>,
 }

--- a/src/vertex_pulling/draw.rs
+++ b/src/vertex_pulling/draw.rs
@@ -49,7 +49,7 @@ impl<P: PhaseItem> RenderCommand<P> for SetCuboidsPipeline {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct ViewMeta {
     pub cuboids_view_bind_group: Option<BindGroup>,
 }
@@ -81,7 +81,7 @@ impl<const I: usize> EntityRenderCommand for SetCuboidsViewBindGroup<I> {
 }
 
 /// Hold the bind group for color options and clipping planes.
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct AuxiliaryMeta {
     pub bind_group: Option<BindGroup>,
 }
@@ -110,7 +110,7 @@ impl<const I: usize> EntityRenderCommand for SetAuxBindGroup<I> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct TransformsMeta {
     pub transform_buffer_bind_group: Option<BindGroup>,
 }

--- a/src/vertex_pulling/extract.rs
+++ b/src/vertex_pulling/extract.rs
@@ -1,11 +1,10 @@
 use super::cuboid_cache::CuboidBufferCache;
+use super::buffers::*;
 use crate::clipping_planes::*;
 use crate::cuboids::*;
-use crate::ColorOptions;
 use crate::ColorOptionsId;
 use crate::ColorOptionsMap;
 
-use bevy::render::render_resource::{DynamicUniformBuffer, UniformBuffer};
 use bevy::{prelude::*, render::Extract};
 
 #[allow(clippy::type_complexity)]
@@ -21,9 +20,9 @@ pub(crate) fn extract_cuboids(
         )>,
     >,
     color_options: Extract<Res<ColorOptionsMap>>,
-    mut color_options_uniforms: ResMut<DynamicUniformBuffer<ColorOptions>>,
+    mut color_options_uniforms: ResMut<DynamicUniformBufferOfColorOptions>,
     mut cuboid_buffers: ResMut<CuboidBufferCache>,
-    mut transform_uniforms: ResMut<DynamicUniformBuffer<CuboidsTransform>>,
+    mut transform_uniforms: ResMut<DynamicUniformBufferOfCuboidTransforms>,
 ) {
     transform_uniforms.clear();
 
@@ -74,7 +73,7 @@ pub(crate) fn extract_cuboids(
 
 pub(crate) fn extract_clipping_planes(
     clipping_planes: Extract<Query<(&ClippingPlaneRange, &GlobalTransform)>>,
-    mut clipping_plane_uniform: ResMut<UniformBuffer<GpuClippingPlaneRanges>>,
+    mut clipping_plane_uniform: ResMut<UniformBufferOfGpuClippingPlaneRanges>,
 ) {
     let mut iter = clipping_planes.iter();
     let mut gpu_planes = GpuClippingPlaneRanges::default();

--- a/src/vertex_pulling/pipeline.rs
+++ b/src/vertex_pulling/pipeline.rs
@@ -20,6 +20,7 @@ use bevy::{
     },
 };
 
+#[derive(Resource)]
 pub(crate) struct CuboidsPipeline {
     pub pipeline_id: CachedRenderPipelineId,
     pub aux_layout: BindGroupLayout,
@@ -179,7 +180,7 @@ impl FromWorld for CuboidsPipeline {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Resource)]
 pub(crate) struct CuboidsShaderDefs {
     pub vertex: Vec<String>,
     pub fragment: Vec<String>,

--- a/src/vertex_pulling/plugin.rs
+++ b/src/vertex_pulling/plugin.rs
@@ -7,15 +7,13 @@ use super::prepare::{
     prepare_cuboid_transforms, prepare_cuboids, prepare_cuboids_view_bind_group,
 };
 use super::queue::queue_cuboids;
-use crate::clipping_planes::GpuClippingPlaneRanges;
-use crate::cuboids::CuboidsTransform;
-use crate::{ColorOptions, ColorOptionsMap};
+use crate::{ColorOptionsMap};
+use super::buffers::*;
 
 use bevy::core_pipeline::core_3d::Opaque3d;
 use bevy::prelude::*;
 use bevy::render::{
     render_phase::AddRenderCommand,
-    render_resource::{DynamicUniformBuffer, UniformBuffer},
     RenderApp, RenderStage,
 };
 
@@ -60,10 +58,10 @@ impl Plugin for VertexPullingRenderPlugin {
             .init_resource::<AuxiliaryMeta>()
             .init_resource::<CuboidBufferCache>()
             .init_resource::<CuboidsPipeline>()
-            .init_resource::<DynamicUniformBuffer<ColorOptions>>()
-            .init_resource::<DynamicUniformBuffer<CuboidsTransform>>()
+            .init_resource::<DynamicUniformBufferOfColorOptions>()
+            .init_resource::<DynamicUniformBufferOfCuboidTransforms>()
             .init_resource::<TransformsMeta>()
-            .init_resource::<UniformBuffer<GpuClippingPlaneRanges>>()
+            .init_resource::<UniformBufferOfGpuClippingPlaneRanges>()
             .init_resource::<ViewMeta>()
             .add_system_to_stage(RenderStage::Extract, extract_cuboids)
             .add_system_to_stage(RenderStage::Extract, extract_clipping_planes)

--- a/src/vertex_pulling/prepare.rs
+++ b/src/vertex_pulling/prepare.rs
@@ -1,14 +1,11 @@
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::{AuxiliaryMeta, TransformsMeta, ViewMeta};
 use super::pipeline::CuboidsPipeline;
-use crate::cuboids::CuboidsTransform;
-use crate::{ColorOptions, GpuClippingPlaneRanges};
+use super::buffers::*;
 
 use bevy::{
     prelude::*,
     render::{
-        render_resource::DynamicUniformBuffer,
-        render_resource::UniformBuffer,
         render_resource::{BindGroupDescriptor, BindGroupEntry},
         renderer::{RenderDevice, RenderQueue},
         view::ViewUniforms,
@@ -18,7 +15,7 @@ use bevy::{
 pub(crate) fn prepare_clipping_planes(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut clipping_plane_uniform: ResMut<UniformBuffer<GpuClippingPlaneRanges>>,
+    mut clipping_plane_uniform: ResMut<UniformBufferOfGpuClippingPlaneRanges>,
 ) {
     // Values already pushed in extract stage.
     clipping_plane_uniform.write_buffer(&render_device, &render_queue);
@@ -27,7 +24,7 @@ pub(crate) fn prepare_clipping_planes(
 pub(crate) fn prepare_color_options(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut color_options_uniforms: ResMut<DynamicUniformBuffer<ColorOptions>>,
+    mut color_options_uniforms: ResMut<DynamicUniformBufferOfColorOptions>,
 ) {
     // Values already pushed in extract stage.
     color_options_uniforms.write_buffer(&render_device, &render_queue);
@@ -37,8 +34,8 @@ pub(crate) fn prepare_auxiliary_bind_group(
     pipeline: Res<CuboidsPipeline>,
     render_device: Res<RenderDevice>,
     mut aux_meta: ResMut<AuxiliaryMeta>,
-    clipping_plane_uniform: Res<UniformBuffer<GpuClippingPlaneRanges>>,
-    color_options_uniform: Res<DynamicUniformBuffer<ColorOptions>>,
+    clipping_plane_uniform: Res<UniformBufferOfGpuClippingPlaneRanges>,
+    color_options_uniform: Res<DynamicUniformBufferOfColorOptions>,
 ) {
     if let (Some(color_binding), Some(planes_binding)) = (
         color_options_uniform.binding(),
@@ -66,7 +63,7 @@ pub(crate) fn prepare_cuboid_transforms(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut transforms_meta: ResMut<TransformsMeta>,
-    mut transform_uniforms: ResMut<DynamicUniformBuffer<CuboidsTransform>>,
+    mut transform_uniforms: ResMut<DynamicUniformBufferOfCuboidTransforms>,
 ) {
     let write_transform_buffer_span =
         bevy::log::info_span!("prepare_cuboids::write_transform_buffer");


### PR DESCRIPTION
I've made migration to bevy 0.9.

Mostly I've just added `#[derive(Resource)` where necessary.
@bonsairobo please also merge this PR: https://github.com/bonsairobo/smooth-bevy-cameras/pull/26