### PR TITLE
upgrade to bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy-aabb-in
 trace = ["bevy/trace_chrome"]
 
 [dependencies.bevy]
-version = "0.9"
+version = "0.10"
 default-features = false
 features = ["bevy_asset", "bevy_core_pipeline", "bevy_render", "x11"]
 
 [dev-dependencies]
 rand = "0.8"
-smooth-bevy-cameras = { git = "https://github.com/olegomon/smooth-bevy-cameras" }
+smooth-bevy-cameras = "0.8"

--- a/examples/wave.rs
+++ b/examples/wave.rs
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<ColorOptionsMap>)
         .spawn(Camera3dBundle::default())
         .insert(FpsCameraBundle::new(
             FpsCameraController {
-                translate_sensitivity: 2.0,
+                translate_sensitivity: 200.0,
                 ..Default::default()
             },
             Vec3::new(0.0, 100.0, 0.0),

--- a/examples/wave.rs
+++ b/examples/wave.rs
@@ -8,7 +8,7 @@ use smooth_bevy_cameras::{controllers::fps::*, LookTransformPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(Msaa { samples: 1 })
+        .insert_resource(Msaa::Off)
         .add_plugin(VertexPullingRenderPlugin { outlines: true })
         .add_plugin(LookTransformPlugin)
         .add_plugin(FpsCameraPlugin::default())
@@ -72,6 +72,7 @@ fn setup(mut commands: Commands, mut color_options_map: ResMut<ColorOptionsMap>)
             },
             Vec3::new(0.0, 100.0, 0.0),
             Vec3::new(100.0, 0.0, 100.0),
+            Vec3::Y,
         ));
 }
 

--- a/src/vertex_pulling.rs
+++ b/src/vertex_pulling.rs
@@ -1,5 +1,6 @@
 // Original copyright: robswain, bevy-vertex-pulling, MIT OR Apache-2.0
 
+mod buffers;
 mod cuboid_cache;
 mod draw;
 mod extract;
@@ -7,6 +8,5 @@ mod index_buffer;
 mod pipeline;
 mod prepare;
 mod queue;
-mod buffers;
 
 pub mod plugin;

--- a/src/vertex_pulling/buffers.rs
+++ b/src/vertex_pulling/buffers.rs
@@ -1,14 +1,18 @@
+use crate::clipping_planes::GpuClippingPlaneRanges;
+use crate::cuboids::CuboidsTransform;
+use crate::ColorOptions;
 use bevy::prelude::{Deref, DerefMut, Resource};
 use bevy::render::render_resource::{DynamicUniformBuffer, UniformBuffer};
-use crate::clipping_planes::GpuClippingPlaneRanges;
-use crate::ColorOptions;
-use crate::cuboids::CuboidsTransform;
 
 #[derive(Resource, Default, Deref, DerefMut)]
 pub(crate) struct DynamicUniformBufferOfColorOptions(pub(crate) DynamicUniformBuffer<ColorOptions>);
 
 #[derive(Resource, Default, Deref, DerefMut)]
-pub(crate) struct DynamicUniformBufferOfCuboidTransforms(pub(crate) DynamicUniformBuffer<CuboidsTransform>);
+pub(crate) struct DynamicUniformBufferOfCuboidTransforms(
+    pub(crate) DynamicUniformBuffer<CuboidsTransform>,
+);
 
 #[derive(Resource, Default, Deref, DerefMut)]
-pub(crate) struct UniformBufferOfGpuClippingPlaneRanges(pub(crate) UniformBuffer<GpuClippingPlaneRanges>);
+pub(crate) struct UniformBufferOfGpuClippingPlaneRanges(
+    pub(crate) UniformBuffer<GpuClippingPlaneRanges>,
+);

--- a/src/vertex_pulling/draw.rs
+++ b/src/vertex_pulling/draw.rs
@@ -1,53 +1,25 @@
-use super::{
-    cuboid_cache::CuboidBufferCache, index_buffer::CuboidsIndexBuffer, pipeline::CuboidsPipeline,
-};
-
+use super::{cuboid_cache::CuboidBufferCache, index_buffer::CuboidsIndexBuffer};
 use bevy::{
     ecs::system::{lifetimeless::*, SystemParamItem},
     prelude::*,
     render::{
         render_asset::RenderAssets,
         render_phase::{
-            EntityRenderCommand, PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass,
+            PhaseItem, RenderCommand, RenderCommandResult, SetItemPipeline, TrackedRenderPass,
         },
-        render_resource::{BindGroup, IndexFormat, PipelineCache},
+        render_resource::{BindGroup, IndexFormat},
         view::ViewUniformOffset,
     },
 };
 
 pub(crate) type DrawCuboids = (
-    SetCuboidsPipeline,
+    SetItemPipeline,
     SetCuboidsViewBindGroup<0>,
     SetAuxBindGroup<1>,
     SetGpuTransformBufferBindGroup<2>,
     SetGpuCuboidBuffersBindGroup<3>,
     DrawVertexPulledCuboids,
 );
-
-pub(crate) struct SetCuboidsPipeline;
-
-impl<P: PhaseItem> RenderCommand<P> for SetCuboidsPipeline {
-    type Param = (SRes<PipelineCache>, SRes<CuboidsPipeline>);
-
-    #[inline]
-    fn render<'w>(
-        _view: Entity,
-        _item: &P,
-        params: SystemParamItem<'w, '_, Self::Param>,
-        pass: &mut TrackedRenderPass<'w>,
-    ) -> RenderCommandResult {
-        let (pipeline_cache, cuboids_pipeline) = params;
-        if let Some(pipeline) = pipeline_cache
-            .into_inner()
-            .get_render_pipeline(cuboids_pipeline.pipeline_id)
-        {
-            pass.set_render_pipeline(pipeline);
-            RenderCommandResult::Success
-        } else {
-            RenderCommandResult::Failure
-        }
-    }
-}
 
 #[derive(Default, Resource)]
 pub struct ViewMeta {
@@ -56,16 +28,18 @@ pub struct ViewMeta {
 
 pub(crate) struct SetCuboidsViewBindGroup<const I: usize>;
 
-impl<const I: usize> EntityRenderCommand for SetCuboidsViewBindGroup<I> {
-    type Param = (SRes<ViewMeta>, SQuery<Read<ViewUniformOffset>>);
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetCuboidsViewBindGroup<I> {
+    type Param = SRes<ViewMeta>;
+    type ItemWorldQuery = ();
+    type ViewWorldQuery = Read<ViewUniformOffset>;
     #[inline]
     fn render<'w>(
-        view: Entity,
-        _item: Entity,
-        (view_meta, view_query): SystemParamItem<'w, '_, Self::Param>,
+        _item: &P,
+        view_uniform_offset: &'_ ViewUniformOffset,
+        _entity: (),
+        view_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let view_uniform_offset = view_query.get(view).unwrap();
         pass.set_bind_group(
             I,
             view_meta
@@ -75,7 +49,6 @@ impl<const I: usize> EntityRenderCommand for SetCuboidsViewBindGroup<I> {
                 .unwrap(),
             &[view_uniform_offset.offset],
         );
-
         RenderCommandResult::Success
     }
 }
@@ -88,19 +61,22 @@ pub struct AuxiliaryMeta {
 
 pub(crate) struct SetAuxBindGroup<const I: usize>;
 
-impl<const I: usize> EntityRenderCommand for SetAuxBindGroup<I> {
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetAuxBindGroup<I> {
     type Param = (SRes<CuboidBufferCache>, SRes<AuxiliaryMeta>);
+    type ItemWorldQuery = Entity;
+    type ViewWorldQuery = ();
 
     #[inline]
     fn render<'w>(
-        _view: Entity,
-        item: Entity,
+        _item: &P,
+        _view: (),
+        entity: Entity,
         (buffer_cache, aux_meta): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let buffer_cache = buffer_cache.into_inner();
         let aux_meta = aux_meta.into_inner();
-        let entry = buffer_cache.entries.get(&item).unwrap();
+        let entry = buffer_cache.entries.get(&entity).unwrap();
         pass.set_bind_group(
             I,
             aux_meta.bind_group.as_ref().unwrap(),
@@ -117,18 +93,21 @@ pub struct TransformsMeta {
 
 pub(crate) struct SetGpuTransformBufferBindGroup<const I: usize>;
 
-impl<const I: usize> EntityRenderCommand for SetGpuTransformBufferBindGroup<I> {
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetGpuTransformBufferBindGroup<I> {
     type Param = (SRes<CuboidBufferCache>, SRes<TransformsMeta>);
+    type ItemWorldQuery = Entity;
+    type ViewWorldQuery = ();
 
     #[inline]
     fn render<'w>(
-        _view: Entity,
-        item: Entity,
+        _item: &P,
+        _view: (),
+        entity: Entity,
         (buffer_cache, transforms_meta): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let transforms_meta = transforms_meta.into_inner();
-        let entry = buffer_cache.into_inner().entries.get(&item).unwrap();
+        let entry = buffer_cache.into_inner().entries.get(&entity).unwrap();
         pass.set_bind_group(
             I,
             transforms_meta
@@ -143,17 +122,20 @@ impl<const I: usize> EntityRenderCommand for SetGpuTransformBufferBindGroup<I> {
 
 pub(crate) struct SetGpuCuboidBuffersBindGroup<const I: usize>;
 
-impl<const I: usize> EntityRenderCommand for SetGpuCuboidBuffersBindGroup<I> {
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetGpuCuboidBuffersBindGroup<I> {
     type Param = SRes<CuboidBufferCache>;
+    type ItemWorldQuery = Entity;
+    type ViewWorldQuery = ();
 
     #[inline]
     fn render<'w>(
-        _view: Entity,
-        item: Entity,
+        _item: &P,
+        _view: (),
+        entity: Entity,
         buffer_cache: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let entry = buffer_cache.into_inner().entries.get(&item).unwrap();
+        let entry = buffer_cache.into_inner().entries.get(&entity).unwrap();
         pass.set_bind_group(I, entry.instance_buffer_bind_group.as_ref().unwrap(), &[]);
         RenderCommandResult::Success
     }
@@ -161,21 +143,24 @@ impl<const I: usize> EntityRenderCommand for SetGpuCuboidBuffersBindGroup<I> {
 
 pub(crate) struct DrawVertexPulledCuboids;
 
-impl EntityRenderCommand for DrawVertexPulledCuboids {
+impl<P: PhaseItem> RenderCommand<P> for DrawVertexPulledCuboids {
     type Param = (
         SRes<CuboidBufferCache>,
         SRes<RenderAssets<CuboidsIndexBuffer>>,
     );
+    type ItemWorldQuery = Entity;
+    type ViewWorldQuery = ();
 
     #[inline]
     fn render<'w>(
-        _view: Entity,
-        item: Entity,
+        _item: &P,
+        _view: (),
+        entity: Entity,
         (buffer_cache, index_buffers): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         use super::index_buffer::{CUBE_INDICES, CUBE_INDICES_HANDLE};
-        let entry = buffer_cache.into_inner().entries.get(&item).unwrap();
+        let entry = buffer_cache.into_inner().entries.get(&entity).unwrap();
         let num_cuboids = entry.instance_buffer.get().len().try_into().unwrap();
         let index_buffer = index_buffers
             .into_inner()

--- a/src/vertex_pulling/pipeline.rs
+++ b/src/vertex_pulling/pipeline.rs
@@ -110,10 +110,7 @@ impl FromWorld for CuboidsPipeline {
             }],
         });
 
-        let sample_count = world
-            .get_resource::<Msaa>()
-            .map(|m| m.samples())
-            .unwrap_or(1);
+        let sample_count = world.resource::<Msaa>().samples();
         let shader_defs = world.resource::<CuboidsShaderDefs>();
         let pipeline_descriptor = RenderPipelineDescriptor {
             label: Some("cuboids_pipeline".into()),

--- a/src/vertex_pulling/pipeline.rs
+++ b/src/vertex_pulling/pipeline.rs
@@ -190,9 +190,7 @@ pub(crate) struct CuboidsShaderDefs {
 
 impl CuboidsShaderDefs {
     pub fn enable_outlines(&mut self) {
-        self.vertex
-            .push(ShaderDefVal::Bool("OUTLINES".into(), true));
-        self.fragment
-            .push(ShaderDefVal::Bool("OUTLINES".into(), true));
+        self.vertex.push("OUTLINES".into());
+        self.fragment.push("OUTLINES".into());
     }
 }

--- a/src/vertex_pulling/plugin.rs
+++ b/src/vertex_pulling/plugin.rs
@@ -1,3 +1,4 @@
+use super::buffers::*;
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::{AuxiliaryMeta, DrawCuboids, TransformsMeta, ViewMeta};
 use super::extract::{extract_clipping_planes, extract_cuboids};
@@ -7,15 +8,11 @@ use super::prepare::{
     prepare_cuboid_transforms, prepare_cuboids, prepare_cuboids_view_bind_group,
 };
 use super::queue::queue_cuboids;
-use crate::{ColorOptionsMap};
-use super::buffers::*;
-
+use crate::ColorOptionsMap;
 use bevy::core_pipeline::core_3d::Opaque3d;
 use bevy::prelude::*;
-use bevy::render::{
-    render_phase::AddRenderCommand,
-    RenderApp, RenderStage,
-};
+use bevy::render::RenderSet;
+use bevy::render::{render_phase::AddRenderCommand, RenderApp};
 
 /// Renders the [`Cuboids`](crate::Cuboids) component using the "vertex pulling" technique.
 #[derive(Default)]
@@ -63,22 +60,22 @@ impl Plugin for VertexPullingRenderPlugin {
             .init_resource::<TransformsMeta>()
             .init_resource::<UniformBufferOfGpuClippingPlaneRanges>()
             .init_resource::<ViewMeta>()
-            .add_system_to_stage(RenderStage::Extract, extract_cuboids)
-            .add_system_to_stage(RenderStage::Extract, extract_clipping_planes)
-            .add_system_to_stage(RenderStage::Prepare, prepare_color_options)
-            .add_system_to_stage(RenderStage::Prepare, prepare_clipping_planes)
-            .add_system_to_stage(
-                RenderStage::Prepare,
-                prepare_auxiliary_bind_group
-                    .after(prepare_color_options)
-                    .after(prepare_clipping_planes),
+            .add_systems((extract_cuboids, extract_clipping_planes).in_schedule(ExtractSchedule))
+            .add_systems(
+                (
+                    prepare_color_options,
+                    prepare_clipping_planes,
+                    prepare_auxiliary_bind_group
+                        .after(prepare_color_options)
+                        .after(prepare_clipping_planes),
+                    prepare_cuboid_transforms,
+                    prepare_cuboids,
+                )
+                    .in_set(RenderSet::Prepare),
             )
-            .add_system_to_stage(RenderStage::Prepare, prepare_cuboid_transforms)
-            .add_system_to_stage(RenderStage::Prepare, prepare_cuboids)
             // HACK: prepare view bind group should happen in prepare phase, but
             // ViewUniforms resource is not ready until after prepare phase;
             // need system order/label exported from bevy
-            .add_system_to_stage(RenderStage::Queue, prepare_cuboids_view_bind_group)
-            .add_system_to_stage(RenderStage::Queue, queue_cuboids);
+            .add_systems((prepare_cuboids_view_bind_group, queue_cuboids).in_set(RenderSet::Queue));
     }
 }

--- a/src/vertex_pulling/plugin.rs
+++ b/src/vertex_pulling/plugin.rs
@@ -11,6 +11,7 @@ use super::queue::queue_cuboids;
 use crate::ColorOptionsMap;
 use bevy::core_pipeline::core_3d::Opaque3d;
 use bevy::prelude::*;
+use bevy::render::view::ViewSet;
 use bevy::render::RenderSet;
 use bevy::render::{render_phase::AddRenderCommand, RenderApp};
 
@@ -70,12 +71,10 @@ impl Plugin for VertexPullingRenderPlugin {
                         .after(prepare_clipping_planes),
                     prepare_cuboid_transforms,
                     prepare_cuboids,
+                    prepare_cuboids_view_bind_group.after(ViewSet::PrepareUniforms),
                 )
                     .in_set(RenderSet::Prepare),
             )
-            // HACK: prepare view bind group should happen in prepare phase, but
-            // ViewUniforms resource is not ready until after prepare phase;
-            // need system order/label exported from bevy
-            .add_systems((prepare_cuboids_view_bind_group, queue_cuboids).in_set(RenderSet::Queue));
+            .add_system(queue_cuboids.in_set(RenderSet::Queue));
     }
 }

--- a/src/vertex_pulling/prepare.rs
+++ b/src/vertex_pulling/prepare.rs
@@ -1,7 +1,7 @@
+use super::buffers::*;
 use super::cuboid_cache::CuboidBufferCache;
 use super::draw::{AuxiliaryMeta, TransformsMeta, ViewMeta};
 use super::pipeline::CuboidsPipeline;
-use super::buffers::*;
 
 use bevy::{
     prelude::*,

--- a/src/vertex_pulling/prepare.rs
+++ b/src/vertex_pulling/prepare.rs
@@ -87,7 +87,6 @@ pub(crate) fn prepare_cuboid_transforms(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_cuboids(
     pipeline: Res<CuboidsPipeline>,
     render_device: Res<RenderDevice>,

--- a/src/vertex_pulling/vertex_pulling.wgsl
+++ b/src/vertex_pulling/vertex_pulling.wgsl
@@ -154,8 +154,8 @@ fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) ins
     let cuboid_center = (cuboid.min + cuboid.max) / 2.0;
 
     if (clipping_planes.num_ranges > 0u) {
-        let tfm_cuboid_center = transform.m * vec4<f32>(cuboid_center, 1.0);
-        let tfm_cuboid_center = tfm_cuboid_center.xyz / tfm_cuboid_center.w;
+        let tfm_cuboid_center_v4 = transform.m * vec4<f32>(cuboid_center, 1.0);
+        let tfm_cuboid_center = tfm_cuboid_center_v4.xyz / tfm_cuboid_center_v4.w;
 
         // Clip any cuboid instance that falls out of the allowed ranges.
         for (var i = 0u; i < clipping_planes.num_ranges; i++) {
@@ -169,8 +169,8 @@ fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) ins
     }
 
     // Need to do this calculation in cuboid (model) space so our offsets are grid-aligned.
-    let camera_in_cuboid_space = transform.m_inv * vec4<f32>(view.world_position, 1.0);
-    let camera_in_cuboid_space = camera_in_cuboid_space.xyz / camera_in_cuboid_space.w;
+    let camera_in_cuboid_space_v4 = transform.m_inv * vec4<f32>(view.world_position, 1.0);
+    let camera_in_cuboid_space = camera_in_cuboid_space_v4.xyz / camera_in_cuboid_space_v4.w;
     let offset = camera_in_cuboid_space - cuboid_center;
     let mirror_mask =
         u32(offset.x > 0.0) |


### PR DESCRIPTION
The only weird parts of this PR:

1. A subtle behavior change with `RenderCommand`. As of `0.10`, the `RenderCommandState` wrapper will always try to call `Query::get_manual` with the `PhaseItem`'s `Entity`, so it's essential to make sure this `Entity` exists in the render world. I do that by spawning any empty `()` bundle for all of the extracted entities.
2. The WGSL shader compiler now reports an error if you have two conflicting `let` bindings with the same name.